### PR TITLE
Improve request error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ Following config parameters are available:
     	host:port Address to listen on for web interface (default ":9709")
   -query.interval int
       How often should daemon query metrics (default 15)
+  -query.retries int
+      How meny times metrics query should be retried (default 3)
+  -query.timeout int
+      Query timeout (default 15)
   -log.level string
       Logging level (default "info")
   -es.address sting


### PR DESCRIPTION
Currently exporter explodes if ElasticSearch endpoint query timeouts or gets refused.
This PR adds request retry functionality. Metrics counters are reset to `0` if retries depleted.

Changes:
* Add flag `request.timeout` defaults to 15
* Add flag `request.retry` defaults to 3
* Return empty string as cluster name if failed to retrieve

@vinted/sre 